### PR TITLE
Update tile usage

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -62,11 +62,11 @@ The following table provides version and version-support information about Synop
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.1, 2.2, 2.3, 2.4, 2.5 and 2.6</td>
+        <td>v2.3.x, v2.4.x, v2.5.x, and v2.6.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>2.1, 2.2, 2.3, 2.4, 2.5 and 2.6</td>
+        <td>v2.3.x, v2.4.x, v2.5.x, and v2.6.x</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -54,7 +54,7 @@ The following table provides version and version-support information about Synop
     </tr>
     <tr>
         <td>Release date</td>
-        <td>July 08, 2019</td>
+        <td>July 09, 2019</td>
     </tr>
     <tr>
         <td>Seeker</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -50,11 +50,11 @@ The following table provides version and version-support information about Synop
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.50</td>
+        <td>v1.2.14</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>January 31, 2019</td>
+        <td>July 07, 2019</td>
     </tr>
     <tr>
         <td>Seeker</td>
@@ -62,11 +62,11 @@ The following table provides version and version-support information about Synop
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.1, 2.2, 2.3, and 2.4</td>
+        <td>2.1, 2.2, 2.3, 2.4, 2.5 and 2.6</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>2.1, 2.2, 2.3, and 2.4</td>
+        <td>2.1, 2.2, 2.3, 2.4, 2.5 and 2.6</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -54,7 +54,7 @@ The following table provides version and version-support information about Synop
     </tr>
     <tr>
         <td>Release date</td>
-        <td>July 07, 2019</td>
+        <td>July 08, 2019</td>
     </tr>
     <tr>
         <td>Seeker</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -4,6 +4,13 @@ owner: Partners
 ---
 
 <strong><%= modified_date %></strong>
+##<a id="ver"></a> v1.2.14
+
+**Release Date:** July 08, 2019
+
+* Removed embedded buildpacks from tile.
+* Rebuilt the tile using Tile Generator v13.2.0 , which fix known CVEs.
+
 
 ##<a id="ver"></a> v1.0.50
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,7 +6,7 @@ owner: Partners
 <strong><%= modified_date %></strong>
 ##<a id="ver"></a> v1.2.14
 
-**Release Date:** July 08, 2019
+**Release Date:** July 09, 2019
 
 * Removed embedded buildpacks from tile.
 * Rebuilt the tile using Tile Generator v13.2.0 , which fix known CVEs.

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -10,20 +10,19 @@ This topic describes how to use the Synopsys Seeker IAST Service Broker for Pivo
 ##<a id='using'></a> How the Synopsys Seeker IAST Service Broker for PCF Works
 
 
-The Synopsys Seeker IAST Service Broker tile has the following buildpacks embedded in it:
+The Synopsys Seeker IAST Service Broker tile relies on following buildpacks:
 
-1. seeker\_node\_buildpack: used to monitor node apps, forked from: https://github.com/cloudfoundry/nodejs-buildpack
-1. seeker\_java\_buildpack: used to monitor java apps, forked from: https://github.com/cloudfoundry/java-buildpack
+1. https://github.com/synopsys-sig/seeker-nodejs-buildpack - used to monitor node apps, forked from: https://github.com/cloudfoundry/nodejs-buildpack
+1. https://github.com/synopsys-sig/seeker-java-buildpack - used to monitor java apps, forked from: https://github.com/cloudfoundry/java-buildpack
 
 Each buildpack is in charge of pulling the agent from the server and injecting 
 it into the app during the deployment.
 
-The buildpack then sets the following environment variables:
+The buildpack then sets the following environment variable:
 
-* SEEKER\_SENSOR\_HOST
-* SEEKER\_SENSOR\_HTTP\_PORT
+* SEEKER_SERVER_URL
 
-These variables are used by the agent to communicate with the sensor.  
+This variable is used by the agent to communicate with the server.  
 
 **Java**:  
 In Java apps, the buildpack adds the javaagent jvm argument that points to the `seeker-agent.jar`.
@@ -59,11 +58,11 @@ cf create-service synopsys-seeker standard INSTANCE-NAME
 1. Deploy your app using the custom Seeker buildpack without starting it:  
 **For NodeJS apps**:
 <p><code>
-cf push --no-start -b seeker\_node\_buildpack APP-NAME 
+cf push --no-start -b https://github.com/synopsys-sig/seeker-nodejs-buildpack APP-NAME 
 </code></p>
 **For Java apps**:
 <p><code>
-cf push --no-start -b seeker\_java\_buildpack APP-NAME 
+cf push --no-start -b https://github.com/synopsys-sig/seeker-java-buildpack APP-NAME 
 </code></p>
 1. Bind the service instance of the Seeker service to the app using the command: 
  <p><code>

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -70,7 +70,7 @@ cf bind-service APP-NAME INSTANCE-NAME
  </code></p>
 1. Start the app
 <p><code>
-cf start
+cf start APP-NAME
 </code></p>
 1. Navigate to Seeker Enterprise to view the findings:
 <img src='images/seeker-vuln-list.png'></img>


### PR DESCRIPTION
Update buildpacks usage and env variables used by the buildpacks.

We are no longer using embedded buildpacks in the the tile (to reduce the tile size).
The buildpacks are now available in github.